### PR TITLE
Use custom location

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -18,7 +18,7 @@
         "value": "lawpreview"
       },
       "location": {
-        "value": "eastus"
+        "value": "${AZURE_LOCATION}"
       },
       "LAWsku": {
         "value": "pergb2018"


### PR DESCRIPTION
When running `azd up`, there is a built-in step to let you select a region to use:

![image](https://github.com/user-attachments/assets/95175227-bf58-4d61-9f53-ccc657f89053)

This region can be accessed through `"${AZURE_LOCATION}"`

But currently we are using hard-coded `eastus` region to deploy the azure resources. Same issue exists in [python](https://github.com/Azure-Samples/quote-of-the-day-python/blob/main/infra/main.parameters.json#L21) and [.net](https://github.com/Azure-Samples/quote-of-the-day-dotnet/blob/main/infra/main.parameters.json#L21)

The downside of using hard-coded location is that user may meet this error if there is existing resource in `eastus` region:
![image](https://github.com/user-attachments/assets/42d25b08-bd9c-4178-8a51-9266b578c4e4) 
